### PR TITLE
fixed timer decrement and reset in Action

### DIFF
--- a/datagenerator/actor.py
+++ b/datagenerator/actor.py
@@ -14,7 +14,7 @@ class Actor(object):
             id_start, id_start + size)]
         self._attributes = {}
         self.ops = self.ActorOps(self)
-        self.size = len(self.ids)
+        self.size = size
         self.relationships = {}
 
     def create_relationship(self, name, seed):

--- a/datagenerator/util_functions.py
+++ b/datagenerator/util_functions.py
@@ -8,6 +8,7 @@ import networkx as nx
 from networkx.algorithms import bipartite
 import logging
 
+
 def create_er_social_network(customer_ids, p, seed):
     """
 
@@ -109,7 +110,7 @@ def merge_2_dicts(dict1, dict2, value_merge_func=None):
             if value_merge_func is None:
                 raise ValueError(
                     "Conflict in merged dictionaries: merge function not "
-                    "provided butkey {} exist in both dictionaries".format(
+                    "provided but key {} exists in both dictionaries".format(
                         key))
 
             return value_merge_func(dict1[key], dict2[key])

--- a/tests/mocks/operations.py
+++ b/tests/mocks/operations.py
@@ -13,3 +13,17 @@ class FakeOp(operations.Operation):
     def __call__(self, action_data):
         return self.output, self.logs
 
+
+class MockDropOp(operations.Operation):
+    """
+    simulating an action that drops rows
+    """
+
+    def __init__(self, from_idx, to_idx):
+        self.from_idx = from_idx
+        self.to_idx = to_idx
+
+    def __call__(self, action_data):
+        return action_data.iloc[self.from_idx: self.to_idx, :], {}
+
+

--- a/tests/mocks/random_generators.py
+++ b/tests/mocks/random_generators.py
@@ -3,7 +3,7 @@ from datagenerator.random_generators import *
 
 class ConstantsMockGenerator(Generator):
     """
-    For test only: a (non random) Genrator returning pre-defined values
+    For test only: a (non random) Generator returning pre-defined values
     """
     def __init__(self, values):
         Generator.__init__(self)
@@ -12,3 +12,16 @@ class ConstantsMockGenerator(Generator):
     def generate(self, size):
         # (value is ignored)
         return self.values
+
+
+class ConstantsProfiler(Generator):
+    """
+    For test only: a (non random) Profiler returning pre-defined values
+    """
+    def __init__(self, values_series):
+        Generator.__init__(self)
+        self.values_series = values_series
+
+    def generate(self, weights):
+        # (value is ignored)
+        return self.values_series[weights.index]

--- a/tests/unit_tests/test_action.py
+++ b/tests/unit_tests/test_action.py
@@ -2,6 +2,7 @@ from datagenerator.actor import Actor
 from datagenerator.action import Action
 from datagenerator.clock import *
 from tests.mocks.random_generators import *
+from tests.mocks.operations import *
 
 
 def test_empty_action_should_do_nothing_and_not_crash():
@@ -18,7 +19,67 @@ def test_empty_action_should_do_nothing_and_not_crash():
     assert logs is None
 
 
-def test_get_activity_default():
+def test_active_inactive_ids_should_say_nothing_active_if_timer_are_positive():
+
+    actor = Actor(size=10, prefix="ac_", max_length=1)
+
+    # 5 actors should trigger in 2 ticks, and 5 more
+    init_timers = pd.Series([2] * 5 + [1] * 5, index=actor.ids)
+    timers_gen = ConstantsProfiler(init_timers)
+
+    action = Action(
+        name="tested",
+        triggering_actor=actor,
+        actorid_field="ac_id",
+
+        # forcing the timer of all actors to be initialized to 0
+        timer_gen=timers_gen,
+        auto_reset_timer=True
+    )
+    assert ([], actor.ids) == action.active_inactive_ids()
+
+
+def test_active_inactive_ids_should_say_5_actives_for_timer_0():
+
+    actor = Actor(size=10, prefix="ac_", max_length=1)
+
+    # 5 actors should trigger in 2 ticks, and 5 more
+    init_timers = pd.Series([0] * 5 + [1] * 5, index=actor.ids)
+    timers_gen = ConstantsProfiler(init_timers)
+
+    action = Action(
+        name="tested",
+        triggering_actor=actor,
+        actorid_field="ac_id",
+
+        # forcing the timer of all actors to be initialized to 0
+        timer_gen=timers_gen,
+        auto_reset_timer=True
+    )
+    assert (actor.ids[:5], actor.ids[5:]) == action.active_inactive_ids()
+
+
+def test_active_inactive_ids_should_all_actives_for_timer_0():
+
+    actor = Actor(size=10, prefix="ac_", max_length=1)
+
+    # 5 actors should trigger in 2 ticks, and 5 more
+    init_timers = pd.Series([0] * 10, index=actor.ids)
+    timers_gen = ConstantsProfiler(init_timers)
+
+    action = Action(
+        name="tested",
+        triggering_actor=actor,
+        actorid_field="ac_id",
+
+        # forcing the timer of all actors to be initialized to 0
+        timer_gen=timers_gen,
+        auto_reset_timer=True
+    )
+    assert (actor.ids, []) == action.active_inactive_ids()
+
+
+def test_get_activity_should_be_default_by_default():
 
     actor = Actor(size=10)
     action = Action(name="tested",
@@ -94,7 +155,7 @@ def test_get_activity_should_be_aligned_for_each_state():
                                               actor.ids, ).tolist()
 
 
-def test_scenario_transiting_to_state_should_remain_there():
+def test_scenario_transiting_to_state_with_0_backprob_should_remain_there():
     """
     we create an action with a transit_to_state operation and 0 probability
     of going back to normal => after the execution, all triggered actors should
@@ -155,7 +216,7 @@ def test_scenario_transiting_to_state_should_remain_there():
     assert expected_state == action.timer["state"].tolist()
 
 
-def test_scenario_transiting_to_state_should_go_back_to_normal():
+def test_scenario_transiting_to_state_with_1_backprob_should_go_back_to_normal():
     """
     similar test to above, though this time we are using
     back_to_normal_prob = 1 => all actors should be back to "normal" state
@@ -211,4 +272,203 @@ def test_scenario_transiting_to_state_should_go_back_to_normal():
     # this time, all actors should have transited back to "normal" at the end
     print action.timer["state"].tolist()
     assert ["default"] * 10 == action.timer["state"].tolist()
+
+
+def test_action_autoreset_true_not_dropping_rows_should_reset_all_timers():
+    # in case an action is configured to perform an auto-reset, after one
+    # execution,
+    #  - all executed rows should have a timer back to some positive value
+    #  - all non executed rows should have gone down one tick
+
+    actor = Actor(size=10, prefix="ac_", max_length=1)
+
+    # 5 actors should trigger in 2 ticks, and 5 more
+    init_timers = pd.Series([2] * 5 + [1] * 5, index=actor.ids)
+    timers_gen = ConstantsProfiler(init_timers)
+
+    action = Action(
+        name="tested",
+        triggering_actor=actor,
+        actorid_field="ac_id",
+
+        # forcing the timer of all actors to be initialized to 0
+        timer_gen=timers_gen,
+        auto_reset_timer=True
+    )
+
+    # empty operation list as initialization
+    action.set_operations(Operation())
+
+    # initial timers should be those provided by the generator
+    assert action.timer["remaining"].equals(init_timers)
+
+    # after one execution, no actor id has been selected and all counters
+    # are decreased by 1
+    action.execute()
+    assert action.timer["remaining"].equals(init_timers - 1)
+
+    # this time, the last 5 should have executed => go back up to 1. The
+    # other 5 should now be at 0, ready to execute at next step
+    action.execute()
+    expected_timers = pd.Series([0] * 5 + [1] * 5, index=actor.ids)
+    assert action.timer["remaining"].equals(expected_timers)
+
+
+def test_action_autoreset_true_and_dropping_rows_should_reset_all_timers():
+    # in case an action is configured to perform an auto-reset, but also
+    # drops some rows, after one execution,
+    #  - all executed rows (dropped or not) should have a timer back to some
+    # positive value
+    #  - all non executed rows should have gone down one tick
+
+    actor = Actor(size=10, prefix="ac_", max_length=1)
+
+    # 5 actors should trigger in 2 ticks, and 5 more
+    init_timers = pd.Series([2] * 5 + [1] * 5, index=actor.ids)
+    timers_gen = ConstantsProfiler(init_timers)
+
+    action = Action(
+        name="tested",
+        triggering_actor=actor,
+        actorid_field="ac_id",
+
+        # forcing the timer of all actors to be initialized to 0
+        timer_gen=timers_gen,
+        auto_reset_timer=True
+    )
+
+    # simulating an operation that drop the last 2 rows
+    action.set_operations(MockDropOp(0, 2))
+
+    # initial timers should be those provided by the generator
+    assert action.timer["remaining"].equals(init_timers)
+
+    # after one execution, no actor id has been selected and all counters
+    # are decreased by 1
+    action.execute()
+    assert action.timer["remaining"].equals(init_timers - 1)
+
+    # this time, the last 5 should have executed => and the last 3 of them
+    # should have been dropped. Nonetheless, all 5 of them should be back to 1
+    action.execute()
+    expected_timers = pd.Series([0] * 5 + [1] * 5, index=actor.ids)
+    assert action.timer["remaining"].equals(expected_timers)
+
+
+def test_action_autoreset_false_not_dropping_rows_should_reset_all_timers():
+    # in case an action is configured not to perform an auto-reset, after one
+    # execution:
+    #  - all executed rows should now be at -1
+    #  - all non executed rows should have gone down one tick
+
+    actor = Actor(size=10, prefix="ac_", max_length=1)
+
+    # 5 actors should trigger in 2 ticks, and 5 more
+    init_timers = pd.Series([2] * 5 + [1] * 5, index=actor.ids)
+    timers_gen = ConstantsProfiler(init_timers)
+
+    action = Action(
+        name="tested",
+        triggering_actor=actor,
+        actorid_field="ac_id",
+
+        # forcing the timer of all actors to be initialized to 0
+        timer_gen=timers_gen,
+        auto_reset_timer=False
+    )
+
+    # empty operation list as initialization
+    action.set_operations(Operation())
+
+    # we have no auto-reset => all timers should intially be at -1
+    all_minus_1 = pd.Series([-1] * 10, index=actor.ids)
+    assert action.timer["remaining"].equals(all_minus_1)
+
+    # executing once => should do nothing, and leave all timers at -1
+    action.execute()
+    assert action.timer["remaining"].equals(all_minus_1)
+
+    # triggering explicitally the action => timers should have the hard-coded
+    # values from the mock generator
+    action.reset_timers()
+    assert action.timer["remaining"].equals(init_timers)
+
+    # after one execution, no actor id has been selected and all counters
+    # are decreased by 1
+    action.execute()
+    assert action.timer["remaining"].equals(init_timers - 1)
+
+    # this time, the last 5 should have executed, but we should not have
+    # any timer reste => they should go to -1.
+    # The other 5 should now be at 0, ready to execute at next step
+    action.execute()
+    expected_timers = pd.Series([0] * 5 + [-1] * 5, index=actor.ids)
+    assert action.timer["remaining"].equals(expected_timers)
+
+    # executing once more: the previously at -1 should still be there, and the
+    # just executed at this stage should be there too
+    action.execute()
+    expected_timers = pd.Series([-1]*10, index=actor.ids)
+    assert action.timer["remaining"].equals(expected_timers)
+
+
+#def test_action_autoreset_false_and_dropping_rows_should_reset_all_timers():
+def test_action():
+    # in case an action is configured not to perform an auto-reset, after one
+    # execution:
+    #  - all executed rows should now be at -1 (dropped or not)
+    #  - all non executed rows should have gone down one tick
+
+    actor = Actor(size=10, prefix="ac_", max_length=1)
+
+    # 5 actors should trigger in 2 ticks, and 5 more
+    init_timers = pd.Series([2] * 5 + [1] * 5, index=actor.ids)
+    timers_gen = ConstantsProfiler(init_timers)
+
+    action = Action(
+        name="tested",
+        triggering_actor=actor,
+        actorid_field="ac_id",
+
+        # forcing the timer of all actors to be initialized to 0
+        timer_gen=timers_gen,
+        auto_reset_timer=False
+    )
+
+    # empty operation list as initialization
+    # simulating an operation that drop the last 2 rows
+    action.set_operations(MockDropOp(0, 2))
+
+    # we have no auto-reset => all timers should intially be at -1
+    all_minus_1 = pd.Series([-1] * 10, index=actor.ids)
+    assert action.timer["remaining"].equals(all_minus_1)
+
+    # executing once => should do nothing, and leave all timers at -1
+    action.execute()
+    assert action.timer["remaining"].equals(all_minus_1)
+
+    # triggering explicitaly the action => timers should have the hard-coded
+    # values from the mock generator
+    action.reset_timers()
+    assert action.timer["remaining"].equals(init_timers)
+
+    # after one execution, no actor id has been selected and all counters
+    # are decreased by 1
+    action.execute()
+    assert action.timer["remaining"].equals(init_timers - 1)
+
+    # this time, the last 5 should have executed, but we should not have
+    # any timer reste => they should go to -1.
+    # The other 5 should now be at 0, ready to execute at next step
+    action.execute()
+    expected_timers = pd.Series([0] * 5 + [-1] * 5, index=actor.ids)
+    assert action.timer["remaining"].equals(expected_timers)
+
+    # executing once more: the previously at -1 should still be there, and the
+    # just executed at this stage should be there too
+    action.execute()
+    expected_timers = pd.Series([-1]*10, index=actor.ids)
+    assert action.timer["remaining"].equals(expected_timers)
+
+
 

--- a/tests/unit_tests/test_actor.py
+++ b/tests/unit_tests/test_actor.py
@@ -1,5 +1,4 @@
 from datagenerator.actor import Actor
-from datagenerator.attribute import *
 
 
 def test_resulting_size_should_be_as_expected():

--- a/tests/unit_tests/test_util_functions.py
+++ b/tests/unit_tests/test_util_functions.py
@@ -33,10 +33,9 @@ def test_merge_non_overlapping_dict_should_return_all_values():
     assert {"a": 1, "b": 2, "c": 3, "d": 4} == merge_2_dicts(d1, d2)
 
 
-def test_merge_dict_to_itslef_should_return_doubled_values():
+def test_merge_dict_to_itself_should_return_doubled_values():
 
     d1 = {"a": 1, "b": 2}
-
     assert {"a": 2, "b": 4} == merge_2_dicts(d1, d1, lambda a, b: a+b)
 
 


### PR DESCRIPTION
This PR is just a bugfix of the way the timer of the actions gets decreased, following a remark from Thoralf earlier today. 
- only actors ids that did not get triggered at this clock tick have their timer decreased after an execution, instead of all of them previously
- if auto_reset==True, all actors that got triggered at this clock tick have their timer reset after the execution, even the ones that got rows dropped
- if auto_reset==False, all actors that got triggered at this clock tick have their timer go down to -1 and stay there after the execution , even the ones that got rows dropped
