### PR TITLE
Activity is now easier to configure

### DIFF
--- a/datagenerator/core/clock.py
+++ b/datagenerator/core/clock.py
@@ -127,6 +127,7 @@ class CyclicTimerGenerator(DependentGenerator):
         """
         DependentGenerator.__init__(self)
         self._state = RandomState(seed)
+        self.config = config
 
         # "macro" time shift: we shift the whole profile n times in the future
         # or the past until it overlaps with the current clock date
@@ -193,6 +194,19 @@ class CyclicTimerGenerator(DependentGenerator):
         return pd.Series(self.profile["cdf"].searchsorted(p),
                          index=observations.index)
 
+    def activity(self, n_actions, per):
+        """
+
+        :param n_actions: number of actions
+        :param per: time period for that number of actions
+        :type per: pd.Timedelta
+        :return: the activity level corresponding to the specified number of
+        action per time perio
+        """
+
+        scale = self.config.duration().total_seconds() / per.total_seconds()
+        return n_actions * scale
+
 
 class CyclicTimerProfile(object):
     """
@@ -241,3 +255,9 @@ class CyclicTimerProfile(object):
 
         return CyclicTimerProfile(profile, profile_time_steps, start_date)
 
+    def duration(self):
+        """
+        :return: the total duration corresponding to this time profile
+        """
+
+        return len(self.profile) * pd.Timedelta(self.profile_time_steps)

--- a/tests/scenarios/snd/snd.py
+++ b/tests/scenarios/snd/snd.py
@@ -31,16 +31,19 @@ scenario_0 = {
 
     "mean_known_sites_per_customer": 4,
 
-    "mean_daily_mobility_activity": 3,
-    "std_daily_mobility_activity": .5,
+    "mean_daily_customer_mobility_activity": 2,
+    "std_daily_customer_mobility_activity": .5,
 
-    "clock_time_step": "5 min",
+    "mean_daily_fa_mobility_activity": 5,
+    "std_daily_fa_mobility_activity": .5,
+
+    "clock_time_step": "15 min",
     "n_init_sim_per_pos": 100,
     "n_init_sim_per_dealer": 1000,
     "sim_price": 10,
 
     "simulation_start_date": "13 Sept 2016 12:00",
-    "simulation_duration": "12h",
+    "simulation_duration": "2 days",
     "output_folder": "snd_output_logs/scenario_0"
 }
 
@@ -79,7 +82,7 @@ class SND(WithBelgium):
         snd_customers.add_purchase_sim_action(self, params)
 
         self.field_agents = snd_field_agents.create_field_agents(self, params)
-        snd_field_agents.add_mobility_action(self)
+        snd_field_agents.add_mobility_action(self, params)
         snd_field_agents.add_survey_action(self)
 
 

--- a/tests/scenarios/snd/snd_customers.py
+++ b/tests/scenarios/snd/snd_customers.py
@@ -56,8 +56,8 @@ def add_mobility_action(circus, params):
     )
 
     gaussian_activity = NumpyRandomGenerator(
-        method="normal", loc=params["mean_daily_mobility_activity"],
-        scale=params["std_daily_mobility_activity"])
+        method="normal", loc=params["mean_daily_customer_mobility_activity"],
+        scale=params["std_daily_customer_mobility_activity"])
     mobility_activity_gen = TransformedGenerator(
         upstream_gen=gaussian_activity,
         f=lambda a: max(.5, a))
@@ -107,9 +107,14 @@ def add_purchase_sim_action(circus, params):
     purchase_timer_gen = DefaultDailyTimerGenerator(circus.clock,
                                                     circus.seeder.next())
 
-    # between 1 to 6 SIM bought per year per customer
+    min_purchase_activity = purchase_timer_gen.activity(
+        n_actions=1, per=pd.Timedelta("360 days"))
+    max_purchase_activity = purchase_timer_gen.activity(
+        n_actions=6, per=pd.Timedelta("360 days"))
+
     purchase_activity_gen = NumpyRandomGenerator(
-        method="choice", a=np.arange(1, 6) / 360.,
+        method="choice",
+        a=np.arange(min_purchase_activity, max_purchase_activity),
         seed=circus.seeder.next())
 
     purchase_action = circus.create_action(

--- a/tests/scenarios/snd/snd_pos.py
+++ b/tests/scenarios/snd/snd_pos.py
@@ -126,7 +126,7 @@ def _create_attractiveness(circus, pos):
 
 def create_pos(circus, params, sim_id_gen):
 
-    logging.info("creating POS")
+    logging.info("creating {} POS".format(params["n_pos"]))
     pos = Actor(size=params["n_pos"],
                 ids_gen=SequencialGenerator(prefix="POS_"))
 

--- a/tests/scenarios/snd/snd_sites.py
+++ b/tests/scenarios/snd/snd_sites.py
@@ -34,3 +34,4 @@ def create_sites(circus, params):
     )
 
     return sites
+


### PR DESCRIPTION
Handy accessors added to CylcicTimerGenerator to easily converted desired amount of actions per period into activity levels. 

e.g.: 

```
    min_purchase_activity = purchase_timer_gen.activity(
        n_actions=1, per=pd.Timedelta("360 days"))
    max_purchase_activity = purchase_timer_gen.activity(
        n_actions=6, per=pd.Timedelta("360 days"))
```
- in order to validate SND scenario output files, added some more parameters to SND scenario. 
