### PR TITLE
IMPROVE random_assign output column names

### DIFF
--- a/datagenerator/components/geographies/uganda.py
+++ b/datagenerator/components/geographies/uganda.py
@@ -144,8 +144,8 @@ if __name__ == "__main__":
 
     cell_city_df = make_random_assign(cells.ids, cities.ids, seeder.next())
     cell_city_rel.add_relations(
-        from_ids=cell_city_df["from"],
-        to_ids=cell_city_df["to"])
+        from_ids=cell_city_df["chosen_from_set2"],
+        to_ids=cell_city_df["set1"])
 
     pop_gen = ParetoGenerator(xmin=10000, a=1.4, seed=seeder.next())
     cities.create_attribute("population", init_gen=pop_gen)

--- a/datagenerator/core/util_functions.py
+++ b/datagenerator/core/util_functions.py
@@ -65,7 +65,7 @@ def make_random_assign(set1, set2, seed):
       :return: a dataframe with as many rows as set1
     """
     chosen_froms = RandomState(seed).choice(set2, size=len(set1))
-    return pd.DataFrame({"from": chosen_froms, "to": set1})
+    return pd.DataFrame({"set1": set1, "chosen_from_set2": chosen_froms})
 
 
 def merge_2_dicts(dict1, dict2, value_merge_func=None):

--- a/tests/scenarios/snd/snd_dealer.py
+++ b/tests/scenarios/snd/snd_dealer.py
@@ -23,7 +23,7 @@ def create_dealers(circus, params, sim_id_gen):
         seed=circus.seeder.next())
 
     dealer_sims.add_relations(
-        from_ids=sims_dealer["from"],
-        to_ids=sims_dealer["to"])
+        from_ids=sims_dealer["chosen_from_set2"],
+        to_ids=sims_dealer["set1"])
 
     return dealers

--- a/tests/scenarios/snd/snd_pos.py
+++ b/tests/scenarios/snd/snd_pos.py
@@ -166,19 +166,19 @@ def create_pos(circus, params, sim_id_gen):
         seed=circus.seeder.next())
 
     pos_sims.add_relations(
-        from_ids=sims_dealer["from"],
-        to_ids=sims_dealer["to"])
+        from_ids=sims_dealer["chosen_from_set2"],
+        to_ids=sims_dealer["set1"])
 
     logging.info("assigning a dealer to each POS")
     dealer_of_pos = make_random_assign(
-        set1=circus.dealers.ids,
-        set2=pos.ids,
+        set1=pos.ids,
+        set2=circus.dealers.ids,
         seed=circus.seeder.next())
 
     dealer_rel = pos.create_relationship("DEALER", seed=circus.seeder.next())
     dealer_rel.add_relations(
-        from_ids=dealer_of_pos["from"],
-        to_ids=dealer_of_pos["to"])
+        from_ids=dealer_of_pos["set1"],
+        to_ids=dealer_of_pos["chosen_from_set2"])
 
     logging.info("generating size of sim bulk purchase for each pos")
     sim_bulk_gen = ParetoGenerator(xmin=500, a=1.5, force_int=True,

--- a/tests/scenarios/test_snd.py
+++ b/tests/scenarios/test_snd.py
@@ -75,7 +75,8 @@ class SndScenario(WithRandomGeo, Circus):
         sim_ids = sim_generator.generate(params["n_init_sims_distributor"])
         sims_dist = make_random_assign(set1=sim_ids, set2=distributors.ids,
                                        seed=self.seeder.next())
-        sims.add_relations(from_ids=sims_dist["from"], to_ids=sims_dist["to"])
+        sims.add_relations(from_ids=sims_dist["chosen_from_set2"],
+                           to_ids=sims_dist["set1"])
 
         # this tells to the "restock" action of the distributor how many
         # sim should be re-generated to replenish the stocks
@@ -139,7 +140,8 @@ class SndScenario(WithRandomGeo, Circus):
         sim_ids = build_ids(size=params["n_init_sims_dealer"], prefix="SIM_")
         sims_dealer = make_random_assign(set1=sim_ids, set2=dealers.ids,
                                          seed=self.seeder.next())
-        sims.add_relations(from_ids=sims_dealer["from"], to_ids=sims_dealer["to"])
+        sims.add_relations(from_ids=sims_dealer["chosen_from_set2"],
+                           to_ids=sims_dealer["set1"])
 
         # one more dealer with just 3 sims in stock => this one will trigger
         # lot's of failed sales

--- a/tests/unit_tests/test_util_functions.py
+++ b/tests/unit_tests/test_util_functions.py
@@ -98,10 +98,10 @@ def test_make_random_assign_shoud_assign_each_element_only_once():
     assert assignment.shape == (1000, 2)
 
     # all SIM should have been given
-    assert set(assignment["to"].unique().tolist()) == set(sims)
+    assert set(assignment["set1"].unique().tolist()) == set(sims)
 
     # all owners should be part of the dealers
-    assert set(assignment["from"].unique().tolist()) <= set(dealers)
+    assert set(assignment["chosen_from_set2"].unique().tolist()) <= set(dealers)
 
 
 def test_cap_to_total_should_leave_untouched_values_below_target():


### PR DESCRIPTION
`from` and `to` was too ambiguous and would be used in the from or to  of a relationship depending on the context.

We hope to remove any ambiguity with these new names.
