### PR TITLE
SND circus is not built with all products

### DIFF
--- a/datagenerator/components/db.py
+++ b/datagenerator/components/db.py
@@ -97,8 +97,8 @@ def load_empirical_discrete_generator(namespace, gen_id, seed):
 
     gen = NumpyRandomGenerator(
         method="choice",
-        a=df["x"],
-        p=df["px"],
+        a=df["x"].tolist(),
+        p=df["px"].tolist(),
         seed=seed)
 
     return gen

--- a/datagenerator/core/circus.py
+++ b/datagenerator/core/circus.py
@@ -236,11 +236,11 @@ class Circus(object):
             json.dump(config, o, indent=4)
 
         logging.info("saving all actors")
-        for actor_id, ac in self.actors.iteritems():
+        for actor_id, ac in self.actors.items():
             db.save_actor(ac, namespace=self.name, actor_id=actor_id)
 
         logging.info("saving all generators")
-        for gen_id, generator in self.generators.iteritems():
+        for gen_id, generator in self.generators.items():
             db.save_generator(generator, namespace=self.name, gen_id=gen_id)
 
         logging.info("circus saved")
@@ -251,11 +251,11 @@ class Circus(object):
             "circus_name": self.name,
             "master_seed": self.master_seed,
             "actors": {actor_id: actor.description()
-                       for actor_id, actor in self.actors.iteritems()
+                       for actor_id, actor in self.actors.items()
                        },
             "generators": {gen_id: gen.description()
-                       for gen_id, gen in self.generators.iteritems()
-                       },
+                           for gen_id, gen in self.generators.items()
+                           },
         }
 
     def __str__(self):

--- a/tests/scenarios/snd/main_build.py
+++ b/tests/scenarios/snd/main_build.py
@@ -8,13 +8,13 @@ import snd_sites
 import snd_pos
 import snd_dealer
 import snd_field_agents
-
+import patterns
 
 import pandas as pd
 
 static_params = {
 
-    "circus_name": "snd_v1",
+    "circus_name": "snd_v2",
 
     "mean_known_sites_per_customer": 6,
 
@@ -27,27 +27,52 @@ static_params = {
 
     "clock_start_date": "13 Sept 2016 12:00",
 
-    # empirical distribution of pos initial stock level
-    "pos_init_er_stock_distro": "stock_distro_notebook/max_stock500_bulk_100_200_450",
+    "products": {
+        "SIM": {
+            "pos_bulk_purchase_sizes": [5, 10, 15],
+            "pos_bulk_purchase_sizes_dist": [.5, .3, .2],
+            "telco_init_stock_customer_ratio": .05
+        },
+        # electronic recharges
+        "ER": {
+            "pos_init_distro": "stock_distro_notebook/max_stock500_bulk_100_200_450",
+            "pos_bulk_purchase_sizes": [100, 200, 450],
+            "pos_bulk_purchase_sizes_dist": [.4, .3, .3],
+            "telco_init_stock_customer_ratio": 1
+        },
+        # physical recharges
+        "PR": {
+            "pos_bulk_purchase_sizes": [50, 100, 225],
+            "pos_bulk_purchase_sizes_dist": [.4, .3, .3],
+            "telco_init_stock_customer_ratio": .5
+        },
+        "MFS": {
+            "pos_bulk_purchase_sizes": [50, 75, 200],
+            "pos_bulk_purchase_sizes_dist": [.4, .4, .2],
+            "telco_init_stock_customer_ratio": .2
+        },
+        "HANDSET": {
+            "pos_bulk_purchase_sizes": [5, 10],
+            "pos_bulk_purchase_sizes_dist": [.5, .5],
+            "telco_init_stock_customer_ratio": .05
+        },
+    },
 
-    # distribution of POS's bulk size when buying SIMs
-    "pos_sim_bulk_purchase_sizes": [10, 15, 25],
-    "pos_sim_bulk_purchase_sizes_dist": [.5, .3, .2],
 
-    # distribution of POS's bulk size when buying electronic recharges
-    "pos_ers_bulk_purchase_sizes": [100, 200, 450],
-    "pos_ers_bulk_purchase_sizes_dist": [.4, .3, .3],
+    # "geography": "belgium",
+    "geography": "belgium_5",
+    # "n_pos": 50000,
+    "n_pos": 500,
 
-    "geography": "belgium_500",
-    "n_pos": 1000,
-
+    # "n_dealers_l2": 1000,
     "n_dealers_l2": 100,
-    "n_dealers_l1": 25,
+    "n_dealers_l1": 50,
     "n_telcos": 1,
 
-    "n_field_agents": 100,
+    "n_field_agents": 500,
 
-    "n_customers": 50000,
+    # "n_customers": 5000000,
+    "n_customers": 500,
 }
 
 if __name__ == "__main__":
@@ -60,30 +85,29 @@ if __name__ == "__main__":
         start=pd.Timestamp(static_params["clock_start_date"]),
         step_duration=pd.Timedelta(static_params["clock_time_step"]))
 
-    # Generators of item ids, used during the constructions of
-    # the circus as well as during the execution of the actions => attached
-    # to the circus, with their state, to ensure full reproduceability
-    recharge_id_gen = random_generators.SequencialGenerator(prefix="ER_")
-    snd.attach_generator("recharge_id_gen", recharge_id_gen)
-    sim_id_gen = random_generators.SequencialGenerator(prefix="SIM_")
-    snd.attach_generator("sim_id_gen", sim_id_gen)
     distributor_id_gen = random_generators.SequencialGenerator(prefix="DIST_")
-    snd.attach_generator("distributor_id_gen", distributor_id_gen)
 
     snd_sites.add_sites(snd, static_params)
     snd_customers.add_customers(snd, static_params)
 
-    snd_dealer.add_telcos(snd, static_params, distributor_id_gen, sim_id_gen,
-                          recharge_id_gen)
+    snd_pos.add_pos(snd, static_params)
+    snd_dealer.add_telcos(snd, static_params, distributor_id_gen)
+    snd_dealer.create_dealers(snd,
+                              actor_name="dealers_l1", actor_size=static_params["n_dealers_l1"],
+                              params=static_params, actor_id_gen=distributor_id_gen)
+    snd_dealer.create_dealers(snd,
+                              actor_name="dealers_l2", actor_size=static_params["n_dealers_l2"],
+                              params=static_params, actor_id_gen=distributor_id_gen)
 
-    snd_pos.add_pos(snd, static_params, sim_id_gen, recharge_id_gen)
-    snd_dealer.create_dealers_l1(snd, static_params, distributor_id_gen,
-                                 sim_id_gen, recharge_id_gen)
-
-    snd_dealer.create_dealers_l2(snd, static_params, distributor_id_gen,
-                                 sim_id_gen, recharge_id_gen)
-
-    snd_pos.connect_pos_to_dealer_l1(snd)
+    patterns.create_distribution_link(snd,
+                                      from_actor_name="pos",
+                                      to_actor_name="dealers_l2")
+    patterns.create_distribution_link(snd,
+                                      from_actor_name="dealers_l2",
+                                      to_actor_name="dealers_l1")
+    patterns.create_distribution_link(snd,
+                                      from_actor_name="dealers_l1",
+                                      to_actor_name="telcos")
 
     snd_field_agents.create_field_agents(snd, static_params)
 

--- a/tests/scenarios/snd/main_run.py
+++ b/tests/scenarios/snd/main_run.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 
     util_functions.setup_logging()
 
-    snd = circus.Circus.load_from_db(circus_name="snd_v1")
+    snd = circus.Circus.load_from_db(circus_name="snd_v2")
     logging.info("loaded circus:\n{}".format(snd))
 
     snd_customers.add_mobility_action(snd, runtime_params)
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
     # restock action must be built in reverse order since they refer to each other
     # TODO: we should fix that since this also influence the order of the executions
-    # => we'd like to re-stock directly, not with delays due to the size of the hierachy
+    # => we'd like to re-stock directly, not with delays due to the size of the hierarchy
     snd_dealer.add_telco_restock_actions(snd)
     snd_dealer.add_dealers_l1_bulk_purchase_actions(snd, runtime_params)
     snd_dealer.add_dealers_l2_bulk_purchase_actions(snd, runtime_params)
@@ -64,5 +64,5 @@ if __name__ == "__main__":
 
     snd.run(
         duration=pd.Timedelta("1 days"),
-        log_output_folder="snd_output_logs/scenario_0",
+        log_output_folder="snd_output_logs/{}".format(snd.name),
         delete_existing_logs=True)

--- a/tests/scenarios/snd/patterns.py
+++ b/tests/scenarios/snd/patterns.py
@@ -2,6 +2,8 @@
 Re-usable operation chains throughout the SND scenario
 """
 import datagenerator.core.operations as operations
+import datagenerator.core.util_functions as util_functions
+import logging
 
 
 def trigger_action_if_low_stock(
@@ -52,3 +54,26 @@ def scale_quantity_gen(stock_size_gen, scale_factor):
             .map(f=operations.bound_value(lb=1))
 
     return stock_size_gen
+
+
+def create_distribution_link(circus, from_actor_name, to_actor_name):
+    """
+    Create random links between vendors in the SND hierarchy,
+    e.g. "from pos to dealer L2", ...
+    """
+
+    logging.info("linking {} to {}".format(from_actor_name, to_actor_name))
+
+    chose_one_upper = util_functions.make_random_assign(
+        set1=circus.actors[from_actor_name].ids,
+        set2=circus.actors[to_actor_name].ids,
+        seed=circus.seeder.next())
+
+    rel = circus.actors[from_actor_name].create_relationship(
+        name=to_actor_name,
+        seed=circus.seeder.next())
+
+    rel.add_relations(
+        from_ids=chose_one_upper["set1"],
+        to_ids=chose_one_upper["chosen_from_set2"])
+

--- a/tests/scenarios/snd/snd_customers.py
+++ b/tests/scenarios/snd/snd_customers.py
@@ -39,7 +39,7 @@ def add_customers(circus, params):
 
     logging.info(" assigning a first random site to each customer")
     customers.create_attribute(name="CURRENT_SITE",
-                                    init_relationship="POSSIBLE_SITES")
+                               init_relationship="POSSIBLE_SITES")
 
     return customers
 
@@ -131,7 +131,7 @@ def add_purchase_sim_action(circus, params):
     )
 
     _create_customer_purchase_action(
-        circus, purchase_timer_gen, purchase_activity_gen, "SIMS",
+        circus, purchase_timer_gen, purchase_activity_gen, "SIM",
         item_price_gen=ConstantGenerator(value=params["sim_price"]),
         action_name="sim_purchases_to_pos",
         pos_restock_trigger=low_stock_bulk_purchase_trigger,
@@ -168,7 +168,7 @@ def add_purchase_er_action(circus, params):
     _create_customer_purchase_action(
         circus, purchase_timer_gen=purchase_timer_gen,
         purchase_activity_gen=purchase_activity_gen,
-        pos_relationship="ERS",
+        pos_stock_relationship="ER",
         item_price_gen=price_gen,
         action_name="ers_purchases_to_pos",
         pos_restock_trigger=low_stock_pos_bulk_purchase_trigger,
@@ -178,7 +178,7 @@ def add_purchase_er_action(circus, params):
 
 def _create_customer_purchase_action(
         circus, purchase_timer_gen, purchase_activity_gen,
-        pos_relationship, item_price_gen, action_name,
+        pos_stock_relationship, item_price_gen, action_name,
         pos_restock_trigger, pos_restock_action_name):
     """
     Creates an action of Customer buying from POS
@@ -211,7 +211,7 @@ def _create_customer_purchase_action(
             # anything => we could add a re-try mechanism here
             discard_empty=True),
 
-        pos.get_relationship(pos_relationship).ops.select_one(
+        pos.get_relationship(pos_stock_relationship).ops.select_one(
             from_field="POS",
             named_as="BOUGHT_ITEM",
 
@@ -237,7 +237,7 @@ def _create_customer_purchase_action(
 
         patterns.trigger_action_if_low_stock(
             circus,
-            stock_relationship=pos.get_relationship(pos_relationship),
+            stock_relationship=pos.get_relationship(pos_stock_relationship),
             actor_id_field="POS",
             restock_trigger=pos_restock_trigger,
             triggered_action_name=pos_restock_action_name


### PR DESCRIPTION
...although the actions are only applied to ER and SIM

=> the `main_build.py`  and all its sub-functions are now a bit more generic, allowing to build any product. 

Note that only the ERS have an initial distribution as investigated in the notebook, all the others just use the "bulk purchase size distribution" as initial stock size distribution. 

Also, I move the `create_distribution_link` to `snd/patterns.py` for more concision. 
